### PR TITLE
Add Models, Services, and Repositories to support JPA Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+application.properties
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -45,10 +45,32 @@ You can [get it here](https://www.oracle.com/java/technologies/javase-downloads.
 *A Portion of these instructions were taken from the oracle help pages, [here](https://docs.oracle.com/en/java/javase/11/install/installation-jdk-microsoft-windows-platforms.html#GUID-371F38CC-248F-49EC-BB9C-C37FC89E52A0)*.
 If you need more comprehensive information, be sure to visit that page. 
 
+### MySql
+- Required Version: `^5.7`
+
+This project also requires a MySql Database to be running. 
+
+_TODO: setup instructions_
+
 ### Node
+- Required Version: `^14.0`
+
 Node is a Javascript runtime, its package manager holds all of our front end dependencies.
 
 _TODO: add install Instructions_
+
+### Application Properties
+Once set up, you'll need to add your database credentials to the `application.properties` file.
+```
+# For MacOS
+cp application.properties.example application.properties
+
+# for Windows
+copy application.properties.example application.properties
+```
+
+make sure to fill the `application.properties` with the appropriate credentials. 
+
 
 ## Usage 
 To  run the project, you'll want to build it first. To do that, `cd` into the project directory and run:
@@ -63,3 +85,12 @@ To  run the project, you'll want to build it first. To do that, `cd` into the pr
 
 Maven will build the java files and start a local server at http://localhost:8080
 From there you can hit just about any end point in the application.
+
+
+
+## Support 
+Some Useful guides and information for using Spring, Vue, and other technology used in the project can be found here:
+
+- [Building a RESTful service with SpringBoot](https://spring.io/guides/gs/rest-service/)
+- [The VueJS Documentation](https://vuejs.org/v2/guide/) 
+- [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)

--- a/application.properties.example
+++ b/application.properties.example
@@ -1,0 +1,7 @@
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.use-new-id-generator-mappings=false
+
+spring.datasource.url=jdbc:mysql://localhost:3306/smart-home-simulator?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=EST
+spring.datasource.username=root
+spring.datasource.password=

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -31,9 +34,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<scope>runtime</scope>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/schema/smart-home-simulator_2020-10-11.sql
+++ b/schema/smart-home-simulator_2020-10-11.sql
@@ -1,0 +1,123 @@
+# ************************************************************
+# Sequel Pro SQL dump
+# Version 5446
+#
+# https://www.sequelpro.com/
+# https://github.com/sequelpro/sequelpro
+#
+# Host: localhost (MySQL 5.7.26)
+# Database: smart-home-simulator
+# Generation Time: 2020-10-12 01:39:05 +0000
+# ************************************************************
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+SET NAMES utf8mb4;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+
+# Dump of table appliances
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `appliances`;
+
+CREATE TABLE `appliances` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `state` int(11) NOT NULL,
+  `home_id` bigint(20) unsigned DEFAULT NULL,
+  `zone_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `appliances_home_id_foreign` (`home_id`),
+  KEY `appliances_zone_id_foreign` (`zone_id`),
+  CONSTRAINT `appliances_home_id_foreign` FOREIGN KEY (`home_id`) REFERENCES `homes` (`id`),
+  CONSTRAINT `appliances_zone_id_foreign` FOREIGN KEY (`zone_id`) REFERENCES `zones` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table homes
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `homes`;
+
+CREATE TABLE `homes` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `date` datetime NOT NULL,
+  `outside_temp` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table openings
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `openings`;
+
+CREATE TABLE `openings` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `state` smallint(6) NOT NULL DEFAULT '0',
+  `zone_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `openings_zone_id_foreign` (`zone_id`),
+  CONSTRAINT `openings_zone_id_foreign` FOREIGN KEY (`zone_id`) REFERENCES `zones` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table users
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `users`;
+
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `role` enum('admin','user','child') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `home_id` bigint(20) unsigned DEFAULT NULL,
+  `zone_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_email_unique` (`email`),
+  KEY `users_zone_id_foreign` (`zone_id`),
+  KEY `users_home_id_foreign` (`home_id`),
+  CONSTRAINT `users_home_id_foreign` FOREIGN KEY (`home_id`) REFERENCES `homes` (`id`),
+  CONSTRAINT `users_zone_id_foreign` FOREIGN KEY (`zone_id`) REFERENCES `zones` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table zones
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `zones`;
+
+CREATE TABLE `zones` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `temperature` int(11) NOT NULL DEFAULT '21',
+  `home_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `zones_home_id_foreign` (`home_id`),
+  CONSTRAINT `zones_home_id_foreign` FOREIGN KEY (`home_id`) REFERENCES `homes` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/src/main/java/com/soen343/smarthomesimulator/SmartHomeSimulatorApplication.java
+++ b/src/main/java/com/soen343/smarthomesimulator/SmartHomeSimulatorApplication.java
@@ -2,9 +2,10 @@ package com.soen343.smarthomesimulator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class SmartHomeSimulatorApplication {
+public class SmartHomeSimulatorApplication extends SpringBootServletInitializer {
 
 	public static void main(String[] args) {
 		SpringApplication.run(SmartHomeSimulatorApplication.class, args);

--- a/src/main/java/com/soen343/smarthomesimulator/controllers/UserController.java
+++ b/src/main/java/com/soen343/smarthomesimulator/controllers/UserController.java
@@ -1,0 +1,42 @@
+package com.soen343.smarthomesimulator.controllers;
+
+import com.soen343.smarthomesimulator.models.User;
+import com.soen343.smarthomesimulator.services.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class UserController {
+
+    @Autowired UserService userService;
+
+    @GetMapping("/users")
+    public List<User> index() {
+        return userService.findAll();
+    }
+
+    @GetMapping("/user")
+    public User show(@RequestParam(value = "id") Long id) {
+        // TODO: get some user with "id"
+        return userService.findById(id);
+    }
+
+    @PostMapping("/user/store")
+    public String store(@RequestParam(value = "name") String name,
+                        @RequestParam(value = "email") String email,
+                        @RequestParam(value = "password") String password) {
+
+        // TODO: Input Validation
+
+        if (userService.save(new User(name, email, password)) != null) {
+            return "{\"success\": true}";
+        }
+
+        return "{\"success\": false}";
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/models/Appliance.java
+++ b/src/main/java/com/soen343/smarthomesimulator/models/Appliance.java
@@ -1,0 +1,80 @@
+package com.soen343.smarthomesimulator.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Table(name = "appliances")
+public class Appliance {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String type;
+
+    private String name;
+
+    private Integer state;
+
+    @ManyToOne
+    @JoinColumn(name = "home_id")
+    private Home home;
+
+    @ManyToOne
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getState() {
+        return state;
+    }
+
+    public void setState(Integer state) {
+        this.state = state;
+    }
+
+    public Home getHome() {
+        return home;
+    }
+
+    public void setHome(Home home) {
+        this.home = home;
+    }
+
+    public Zone getZone() {
+        return zone;
+    }
+
+    public void setZone(Zone zone) {
+        this.zone = zone;
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/models/Home.java
+++ b/src/main/java/com/soen343/smarthomesimulator/models/Home.java
@@ -1,0 +1,60 @@
+package com.soen343.smarthomesimulator.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "homes")
+public class Home {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String name;
+
+    private Integer outside_temp;
+
+    private Timestamp date;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getOutside_temp() {
+        return outside_temp;
+    }
+
+    public void setOutside_temp(Integer outside_temp) {
+        this.outside_temp = outside_temp;
+    }
+
+    public Timestamp getDate() {
+        return date;
+    }
+
+    public void setDate(Timestamp date) {
+        this.date = date;
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/models/Opening.java
+++ b/src/main/java/com/soen343/smarthomesimulator/models/Opening.java
@@ -1,0 +1,60 @@
+package com.soen343.smarthomesimulator.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+// Windows, Doors, etc...
+@Entity
+@Table(name = "appliances")
+public class Opening {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String type;
+
+    private Integer state;
+
+    @OneToOne
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getState() {
+        return state;
+    }
+
+    public void setState(Integer state) {
+        this.state = state;
+    }
+
+    public Zone getZone() {
+        return zone;
+    }
+
+    public void setZone(Zone zone) {
+        this.zone = zone;
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/models/User.java
+++ b/src/main/java/com/soen343/smarthomesimulator/models/User.java
@@ -1,0 +1,101 @@
+package com.soen343.smarthomesimulator.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String email;
+
+    private String name;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String password;
+
+    @ManyToOne
+    @JoinColumn(name = "home_id")
+    private Home home;
+
+    // If zone is null, user is outside the home they belong to
+    @ManyToOne
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+
+    public User() {
+    }
+
+    public User(Long id, String name,  String email, String password) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.password = password;
+    }
+
+    public User(String name, String email, String password) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Home getHome() {
+        return home;
+    }
+
+    public void setHome(Home home) {
+        this.home = home;
+    }
+
+    public Zone getZone() {
+        return zone;
+    }
+
+    public void setZone(Zone zone) {
+        this.zone = zone;
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/models/Zone.java
+++ b/src/main/java/com/soen343/smarthomesimulator/models/Zone.java
@@ -1,0 +1,54 @@
+package com.soen343.smarthomesimulator.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+@Entity
+@Table(name = "zones")
+public class Zone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String name;
+
+    private Integer temperature;
+
+    @ManyToOne
+    @JoinColumn(name = "home_id")
+    private Home home;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(Integer temperature) {
+        this.temperature = temperature;
+    }
+
+}

--- a/src/main/java/com/soen343/smarthomesimulator/repositories/ApplianceRepository.java
+++ b/src/main/java/com/soen343/smarthomesimulator/repositories/ApplianceRepository.java
@@ -1,0 +1,10 @@
+package com.soen343.smarthomesimulator.repositories;
+
+import com.soen343.smarthomesimulator.models.Appliance;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplianceRepository extends CrudRepository<Appliance, Long> {
+}

--- a/src/main/java/com/soen343/smarthomesimulator/repositories/HomeRepository.java
+++ b/src/main/java/com/soen343/smarthomesimulator/repositories/HomeRepository.java
@@ -1,0 +1,10 @@
+package com.soen343.smarthomesimulator.repositories;
+
+import com.soen343.smarthomesimulator.models.Home;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HomeRepository extends CrudRepository<Home, Long> {
+}

--- a/src/main/java/com/soen343/smarthomesimulator/repositories/OpeningRepository.java
+++ b/src/main/java/com/soen343/smarthomesimulator/repositories/OpeningRepository.java
@@ -1,0 +1,10 @@
+package com.soen343.smarthomesimulator.repositories;
+
+import com.soen343.smarthomesimulator.models.Opening;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OpeningRepository extends CrudRepository<Opening, Long> {
+}

--- a/src/main/java/com/soen343/smarthomesimulator/repositories/UserRepository.java
+++ b/src/main/java/com/soen343/smarthomesimulator/repositories/UserRepository.java
@@ -1,0 +1,10 @@
+package com.soen343.smarthomesimulator.repositories;
+
+import com.soen343.smarthomesimulator.models.User;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends CrudRepository<User, Long> {
+}

--- a/src/main/java/com/soen343/smarthomesimulator/repositories/ZoneRepository.java
+++ b/src/main/java/com/soen343/smarthomesimulator/repositories/ZoneRepository.java
@@ -1,0 +1,10 @@
+package com.soen343.smarthomesimulator.repositories;
+
+import com.soen343.smarthomesimulator.models.Zone;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ZoneRepository extends CrudRepository<Zone, Long> {
+}

--- a/src/main/java/com/soen343/smarthomesimulator/services/ApplianceService.java
+++ b/src/main/java/com/soen343/smarthomesimulator/services/ApplianceService.java
@@ -1,0 +1,16 @@
+package com.soen343.smarthomesimulator.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soen343.smarthomesimulator.repositories.ApplianceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplianceService {
+
+    @Autowired ApplianceRepository repository;
+
+
+}

--- a/src/main/java/com/soen343/smarthomesimulator/services/HomeService.java
+++ b/src/main/java/com/soen343/smarthomesimulator/services/HomeService.java
@@ -1,0 +1,15 @@
+package com.soen343.smarthomesimulator.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soen343.smarthomesimulator.repositories.HomeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HomeService {
+
+    @Autowired HomeRepository repository;
+
+}

--- a/src/main/java/com/soen343/smarthomesimulator/services/OpeningService.java
+++ b/src/main/java/com/soen343/smarthomesimulator/services/OpeningService.java
@@ -1,0 +1,15 @@
+package com.soen343.smarthomesimulator.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soen343.smarthomesimulator.repositories.OpeningRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpeningService {
+
+    @Autowired OpeningRepository repository;
+
+}

--- a/src/main/java/com/soen343/smarthomesimulator/services/UserService.java
+++ b/src/main/java/com/soen343/smarthomesimulator/services/UserService.java
@@ -1,0 +1,30 @@
+package com.soen343.smarthomesimulator.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soen343.smarthomesimulator.models.User;
+import com.soen343.smarthomesimulator.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    @Autowired UserRepository repository;
+
+    public List<User> findAll() {
+        var iterator = repository.findAll();
+        var users = new ArrayList<User>();
+        iterator.forEach(e -> users.add(e));
+
+        return users;
+    }
+
+    public User findById(Long id) {
+        return repository.findById(id).get();
+    }
+
+    public User save(User user) {
+        return repository.save(user);
+    }
+}

--- a/src/main/java/com/soen343/smarthomesimulator/services/ZoneService.java
+++ b/src/main/java/com/soen343/smarthomesimulator/services/ZoneService.java
@@ -1,0 +1,15 @@
+package com.soen343.smarthomesimulator.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soen343.smarthomesimulator.repositories.ZoneRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ZoneService {
+
+    @Autowired ZoneRepository repository;
+
+}

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,15 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link defer rel="stylesheet" type="text/css" th:href="@{/css/app.css}">
     <meta charset="UTF-8">
-    <title>Smart Home Simulator</title>
+    <link defer rel="stylesheet" type="text/css" th:href="@{/css/app.css}">
+    <title>Profile Page</title>
 </head>
 <body>
-<div id="app">
-    <example></example>
-</div>
 
+<example></example>
 
 <script type="text/javascript" th:src="@{/js/app.js}"></script>
 </body>


### PR DESCRIPTION
# Overview
Adds stubs for all models that represent a basic architecture for the REST API.

## Changes
- Add JPA and MySql Dependancies
- Add MySQL Schema
- Add `applications.properties` example file
- Stub out README sections for future documentation
- Add Models with getters and setter for: Appliances, Homes, Opening, Users, and Zones
- Add Services for: Appliances, Homes, Opening, Users, and Zones
- Add Repositories for: Appliances, Homes, Opening, Users, and Zones
- Add Services for: Appliances, Homes, Opening, Users, and Zones
- Add functionality to Users Controller:
   - List all users
   - List specific user
   - Create user